### PR TITLE
docs: Добавить LICENSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-49-cf1042e6
-Your prepared working directory: /tmp/gh-issue-solver-1760557070009
-Your forked repository: konard/integramDD
-Original repository (upstream): unidel2035/integramDD
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: undefined
+Your prepared branch: issue-49-cf1042e6
+Your prepared working directory: /tmp/gh-issue-solver-1760557070009
+Your forked repository: konard/integramDD
+Original repository (upstream): unidel2035/integramDD
+
+Proceed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 unidel2035
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Описание

Добавлен файл LICENSE с лицензией MIT для проекта.

## Что было сделано

- Создан файл LICENSE с полным текстом MIT License
- Указаны авторские права: Copyright (c) 2025 unidel2035
- MIT License выбрана как наиболее подходящая для веб-API проектов

## Обоснование выбора лицензии

MIT License была выбрана по следующим причинам:
- Наиболее permissive лицензия, рекомендованная в issue
- Широко используется для API проектов
- Позволяет коммерческое использование с минимальными ограничениями
- Простая и понятная для пользователей

## Связанные issues

Fixes #49

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)